### PR TITLE
Add support for two-way SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ For other functions, please use the raw_query function until the functions have
 been rewritten.  For detailed documentation for the various other things that
 can be done, please reference the Security Center API documentation.
 
+## SSL Support
+
+If Python is compiled with SSL support, SecurityCenter can support two-way SSL.
+
+  >>> sc = SecurityCenter("ADDRESS", "USER", "PASS",
+  ... key="KEY_FILE_PATH", cert="CERT_FILE_PATH")
+
 # Available Functions
 
 ## raw_query


### PR DESCRIPTION
This commit allows specifying a key and cert file along with the username and password to support two-way SSL.  The server cert is still ignored, but now the provided client key is sent.

This only works if Python was compiled with SSL support.  Although it relies on httplib (which was removed in a previous commit), it should work with Python 2.4, but I didn't test it on anything other than 2.7.
