### PR TITLE
Requests 2.11.0 expects strings in headers

### DIFF
--- a/securitycenter/sc5.py
+++ b/securitycenter/sc5.py
@@ -36,7 +36,7 @@ class SecurityCenter5(BaseAPI):
     def _builder(self, **kwargs):
         kwargs = BaseAPI._builder(self, **kwargs)
         if self._token:
-            kwargs['headers']['X-SecurityCenter'] = self._token
+            kwargs['headers']['X-SecurityCenter'] = str(self._token)
         return kwargs
 
     def login(self, user, passwd):


### PR DESCRIPTION
The current release of requests (2.11.0) now sanitizes headers and only allows strings or bytes. This causes a requests.exceptions.InvalidHeader to be thrown when setting the token in the header.

Steps to reproduce:

make sure requests 2.11.0 is being used

pip install requests==2.11.0


use any sc command (post,get,etc...):

sc = SecurityCenter5(hostname)
sc.login(username, password)
print sc.get('status')


This should give the following error:

requests.exceptions.InvalidHeader: Header value ****** must be of type str or bytes, not <type 'int'>